### PR TITLE
Adding Discriminator support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typegoose",
-  "version": "6.0.0-15",
+  "version": "6.0.0-16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typegoose",
-  "version": "6.0.0-15",
+  "version": "6.0.0-16",
   "description": "Define Mongoose models using TypeScript classes.",
   "main": "lib/typegoose.js",
   "engines": {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -34,6 +34,7 @@ export function _buildSchema<T, U extends NoParamConstructor<T>>(
   if (!sch) {
     sch = new Schema(schemas.get(name), schemaOptions);
   } else {
+    sch = sch.clone();
     sch.add(schemas.get(name));
   }
 

--- a/test/models/discriminators.ts
+++ b/test/models/discriminators.ts
@@ -1,0 +1,14 @@
+import { getDiscriminatorModelForClass, getModelForClass, prop } from '../../src/typegoose';
+
+export class DisMain {
+  @prop({ required: true, default: 'hello main1' })
+  public main1: string;
+}
+
+export class DisAbove extends DisMain {
+  @prop({ required: true, default: 'hello above1' })
+  public above1: string;
+}
+
+export const DisMainModel = getModelForClass(DisMain);
+export const DisAboveModel = getDiscriminatorModelForClass(DisMainModel, DisAbove);

--- a/test/tests/shouldRun.test.ts
+++ b/test/tests/shouldRun.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import * as mongoose from 'mongoose';
 import { buildSchema, getModelForClass, modelOptions } from '../../src/typegoose';
+import { DisAbove, DisAboveModel, DisMain, DisMainModel } from '../models/discriminators';
 
 /**
  * Function to pass into describe
@@ -36,5 +37,21 @@ export function suite() {
     @modelOptions({ existingConnection: mongoose.connection })
     class TESTexistingConnection { }
     expect(getModelForClass(TESTexistingConnection)).to.not.be.an('undefined');
+  });
+
+  it('should make use of discriminators', async () => {
+    const dmmdoc = await DisMainModel.create({ main1: 'hello DMM' } as DisMain);
+    const damdoc = await DisAboveModel.create({ main1: 'hello DAM', above1: 'hello DAM' } as DisAbove);
+    expect(dmmdoc).to.not.be.an('undefined');
+    expect(dmmdoc.main1).to.equals('hello DMM');
+    expect(dmmdoc).to.not.have.property('above1');
+    // any is required otherwise typescript complains about "__t" not existing
+    expect((dmmdoc as any).__t).to.be.an('undefined');
+
+    expect(damdoc).to.not.be.an('undefined');
+    expect(damdoc.main1).to.equals('hello DAM');
+    expect(damdoc.above1).to.equals('hello DAM');
+    // any is required otherwise typescript complains about "__t" not existing
+    expect((damdoc as any).__t).to.equals('DisAbove');
   });
 }


### PR DESCRIPTION
- adding discriminator support
- use "sch.clone()" to clone before assigning to avoid having the properties in the parent schema

better (& working) version of szokodiakos#333