### PR TITLE
R6/typegoose class settings fix

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,5 @@
+export enum DecoratorKeys {
+  Prop = 'design:type',
+  ModelOptions = 'typegoose:options',
+  Index = 'typegoose:indices'
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
+import { DecoratorKeys } from './internal/constants';
+
 /*
  copy-paste from mongodb package (should be same as IndexOptions from 'mongodb')
  */
-import { DecoratorKeys } from './constants';
 
 export interface IndexOptions<T> {
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 /*
  copy-paste from mongodb package (should be same as IndexOptions from 'mongodb')
  */
+import { DecoratorKeys } from './constants';
+
 export interface IndexOptions<T> {
   /**
    * Mongoose-specific syntactic sugar, uses ms to convert

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,8 +73,8 @@ export interface IndexOptions<T> {
  */
 export function index<T>(fields: T, options?: IndexOptions<T>) {
   return (constructor: any) => {
-    const indices: any[] = Reflect.getMetadata('typegoose:indices', constructor) || [];
+    const indices: any[] = Reflect.getMetadata(DecoratorKeys.Index, constructor) || [];
     indices.push({ fields, options });
-    Reflect.defineMetadata('typegoose:indices', indices, constructor);
+    Reflect.defineMetadata(DecoratorKeys.Index, indices, constructor);
   };
 }

--- a/src/internal/constants.ts
+++ b/src/internal/constants.ts
@@ -1,3 +1,6 @@
+/**
+ * Collection of Reflect Types for easy maintenance
+ */
 export enum DecoratorKeys {
   Prop = 'design:type',
   ModelOptions = 'typegoose:options',

--- a/src/internal/schema.ts
+++ b/src/internal/schema.ts
@@ -2,8 +2,8 @@ import * as mongoose from 'mongoose';
 
 import { IModelOptions } from '../typegoose';
 import { EmptyVoidFn, NoParamConstructor } from '../types';
+import { DecoratorKeys } from './constants';
 import { buildSchemas, hooks, plugins, schemas, virtuals } from './data';
-import { DecoratorKeys } from '../constants';
 
 /**
  * Private schema builder out of class props

--- a/src/internal/schema.ts
+++ b/src/internal/schema.ts
@@ -3,6 +3,7 @@ import * as mongoose from 'mongoose';
 import { IModelOptions } from '../typegoose';
 import { EmptyVoidFn, NoParamConstructor } from '../types';
 import { buildSchemas, hooks, plugins, schemas, virtuals } from './data';
+import { DecoratorKeys } from '../constants';
 
 /**
  * Private schema builder out of class props
@@ -25,7 +26,7 @@ export function _buildSchema<T, U extends NoParamConstructor<T>>(
 
   /** Simplify the usage */
   const Schema = mongoose.Schema;
-  const { schemaOptions: ropt }: IModelOptions = Reflect.getMetadata('typegoose:options', cl) || {};
+  const { schemaOptions: ropt }: IModelOptions = Reflect.getMetadata(DecoratorKeys.ModelOptions, cl) || {};
   const schemaOptions = Object.assign(ropt || {}, opt);
 
   if (!schemas.get(name)) {
@@ -66,7 +67,7 @@ export function _buildSchema<T, U extends NoParamConstructor<T>>(
   }
 
   /** Get Metadata for indices */
-  const indices: any[] = Reflect.getMetadata('typegoose:indices', cl) || [];
+  const indices: any[] = Reflect.getMetadata(DecoratorKeys.Index, cl) || [];
   for (const index of indices) {
     sch.index(index.fields, index.options);
   }

--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -149,4 +149,3 @@ export function assignMetadata(key: string, value: unknown, cl: new () => {}): v
   const newValue = Object.assign(current, value);
   Reflect.defineMetadata(key, newValue, cl);
 }
-

--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -137,3 +137,16 @@ allVirtualoptions.push('ref');
 export function includesAllVirtualPOP(options: VirtualOptions): options is VirtualOptions {
   return allVirtualoptions.every((v) => Object.keys(options).includes(v));
 }
+
+/**
+ * Merges existing metadata with new value
+ * @param key Metadata key
+ * @param value Raw value
+ * @param cl The constructor
+ */
+export function assignMetadata(key: string, value: unknown, cl: new () => {}): void {
+  const current = Reflect.getMetadata(key, cl) || {};
+  const newValue = Object.assign(current, value);
+  Reflect.defineMetadata(key, newValue, cl);
+}
+

--- a/src/optionsProp.ts
+++ b/src/optionsProp.ts
@@ -1,4 +1,5 @@
 import * as mongoose from 'mongoose';
+import { DecoratorKeys } from './constants';
 
 export interface IModelOptions {
   /** An Existing Mongoose Connection */
@@ -22,7 +23,7 @@ export interface IModelOptions {
  */
 export function modelOptions(options: IModelOptions) {
   return (constructor: any) => {
-    const rfoptions: IModelOptions = Reflect.getMetadata('typegoose:options', constructor) || {};
-    Reflect.defineMetadata('typegoose:options', Object.assign(rfoptions, options), constructor);
+    const rfoptions: IModelOptions = Reflect.getMetadata(DecoratorKeys.ModelOptions, constructor) || {};
+    Reflect.defineMetadata(DecoratorKeys.ModelOptions, Object.assign(rfoptions, options), constructor);
   };
 }

--- a/src/optionsProp.ts
+++ b/src/optionsProp.ts
@@ -1,5 +1,5 @@
 import * as mongoose from 'mongoose';
-import { DecoratorKeys } from './constants';
+import { DecoratorKeys } from './internal/constants';
 
 export interface IModelOptions {
   /** An Existing Mongoose Connection */

--- a/src/prop.ts
+++ b/src/prop.ts
@@ -1,6 +1,7 @@
 import * as mongoose from 'mongoose';
 
 import { isNullOrUndefined } from 'util';
+import { DecoratorKeys } from './internal/constants';
 import { schemas, virtuals } from './internal/data';
 import {
   InvalidPropError,
@@ -18,7 +19,6 @@ import {
   PropOptions,
   PropOptionsWithValidate
 } from './types';
-import { DecoratorKeys } from './constants';
 
 /** This Enum is meant for baseProp to decide for diffrent props (like if it is an arrayProp or prop or mapProp) */
 enum WhatIsIt {

--- a/src/prop.ts
+++ b/src/prop.ts
@@ -18,6 +18,7 @@ import {
   PropOptions,
   PropOptionsWithValidate
 } from './types';
+import { DecoratorKeys } from './constants';
 
 /** This Enum is meant for baseProp to decide for diffrent props (like if it is an arrayProp or prop or mapProp) */
 enum WhatIsIt {
@@ -260,7 +261,7 @@ function baseProp(
  */
 export function prop(options: PropOptionsWithValidate = {}) {
   return (target: any, key: string) => {
-    const Type = Reflect.getMetadata('design:type', target, key);
+    const Type = Reflect.getMetadata(DecoratorKeys.Prop, target, key);
     if (!Type) {
       throw new NoMetadataError(key);
     }

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -14,6 +14,8 @@ import { buildSchemas, constructors, models } from './internal/data';
 import { _buildSchema } from './internal/schema';
 import { IModelOptions } from './optionsProp';
 import { DocumentType, NoParamConstructor, Ref, ReturnModelType } from './types';
+import { assignMetadata } from './internal/utils';
+import { DecoratorKeys } from './constants';
 
 /* exports */
 export * from './method';
@@ -38,12 +40,16 @@ export abstract class Typegoose {
   /* istanbul ignore next */
   /** @deprecated */
   public getModelForClass<T, U extends NoParamConstructor<T>>(cl: U, settings?: any) {
+    assignMetadata(DecoratorKeys.ModelOptions, settings, cl);
+
     return deprecate(getModelForClass, 'Typegoose Class is Deprecated!')(cl);
   }
 
   /* istanbul ignore next */
   /** @deprecated */
   public setModelForClass<T, U extends NoParamConstructor<T>>(cl: U, settings?: any) {
+    assignMetadata(DecoratorKeys.ModelOptions, settings, cl);
+
     return deprecate(setModelForClass, 'Typegoose Class is Deprecated!')(cl);
   }
 
@@ -73,7 +79,7 @@ export function getModelForClass<T, U extends NoParamConstructor<T>>(cl: U) {
     return models.get(name) as ReturnModelType<U, T>;
   }
 
-  const options: IModelOptions = Reflect.getMetadata('typegoose:options', cl) || {};
+  const options: IModelOptions = Reflect.getMetadata(DecoratorKeys.ModelOptions, cl) || {};
 
   let model = mongoose.model.bind(mongoose);
   if (options.existingConnection) {

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -10,12 +10,12 @@ if (!Object.fromEntries) {
 
 import { deprecate } from 'util';
 import * as defaultClasses from './defaultClasses';
+import { DecoratorKeys } from './internal/constants';
 import { buildSchemas, constructors, models } from './internal/data';
 import { _buildSchema } from './internal/schema';
+import { assignMetadata } from './internal/utils';
 import { IModelOptions } from './optionsProp';
 import { DocumentType, NoParamConstructor, Ref, ReturnModelType } from './types';
-import { assignMetadata } from './internal/utils';
-import { DecoratorKeys } from './constants';
 
 /* exports */
 export * from './method';


### PR DESCRIPTION
This preserves backward compatibility to version 5.x.x. 
Tested with @nestjs/typegoose    