### PR TITLE
Add ModelType export

### DIFF
--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -15,7 +15,7 @@ import { buildSchemas, constructors, models } from './internal/data';
 import { _buildSchema } from './internal/schema';
 import { assignMetadata } from './internal/utils';
 import { IModelOptions } from './optionsProp';
-import { DocumentType, NoParamConstructor, Ref, ReturnModelType } from './types';
+import { DocumentType, NoParamConstructor, Ref, ModelType, ReturnModelType } from './types';
 
 /* exports */
 export * from './method';
@@ -26,7 +26,7 @@ export * from '.';
 export * from './typeguards';
 export * from './optionsProp';
 export { defaultClasses };
-export { DocumentType, Ref, ReturnModelType };
+export { DocumentType, Ref, ModelType, ReturnModelType };
 export { getClassForDocument } from './internal/utils';
 
 /** @deprecated */


### PR DESCRIPTION
We are using the `ModelType` inside our NestsJs application like this: 

````
export class SomeCoolService {
  constructor(
    @InjectModel(SomeEntity)
    private readonly someModel: ModelType<SomeEntity>,
)
}

````

This change would support the backward compatibility with 5.x.x and the typing should be also correct for these use-cases.