### PR TITLE
Decorator Execution Order

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Define Mongoose models using TypeScript classes.
 ## Basic usage
 
 ```ts
-import { prop, getModelForClass } from 'typegoose';
+import { prop, getModelForClass } from '@hasezoey/typegoose';
 import * as mongoose from 'mongoose';
 
 mongoose.connect('mongodb://localhost:27017/test');
@@ -113,13 +113,12 @@ Please note that sub documents do not have to extend Typegoose. You can still gi
 
 * TypeScript 3.2+
 * Node 8+
-* mongoose 5+
+* mongoose ^5.6.9
 * `emitDecoratorMetadata` and `experimentalDecorators` must be enabled in `tsconfig.json`
-* `reflect-metadata` must be installed
 
 ## Install
 
-`npm i -s typegoose`
+`npm i -s @hasezoey/typegoose`
 
 You also need to install `mongoose`, since version 5 it is listed as a peer-dependency
 

--- a/github-page/_guides/known-issues.md
+++ b/github-page/_guides/known-issues.md
@@ -10,7 +10,6 @@ redirect_from:
 - ts-node: never run `ts-node --transpile-only` (seems like ts-node will not fix it)
 - typegoose dosnt work with classes that have the same name [{% include gitissue repo="hasezoey" num=23 %}, {% include gitissue repo="hasezoey" num=24 %}]
 - `@prop` cannot be applied to `get` & `set` (virtuals), because virtuals do not accept options & schema.loadClass wouldnt load these
-- in this PR: `_id: false` does not work, i dont know why
 - please make sure to use the right decorator execution order to prevent something like hook to fail if `@modelOptions` changes the name
 
 [Please look here first, to decide if it is an typegoose/mongoose issue](https://github.com/Automattic/mongoose/issues?utf8=✓&q=is%3Aissue+involves%3Ahasezoey)

--- a/github-page/_guides/known-issues.md
+++ b/github-page/_guides/known-issues.md
@@ -10,6 +10,6 @@ redirect_from:
 - ts-node: never run `ts-node --transpile-only` (seems like ts-node will not fix it)
 - typegoose dosnt work with classes that have the same name [{% include gitissue repo="hasezoey" num=23 %}, {% include gitissue repo="hasezoey" num=24 %}]
 - `@prop` cannot be applied to `get` & `set` (virtuals), because virtuals do not accept options & schema.loadClass wouldnt load these
-- please make sure to use the right decorator execution order to prevent something like hook to fail if `@modelOptions` changes the name
+- please make sure to use the right decorator execution order to prevent something like hook to fail if `@modelOptions` changes the name, [here is a reference](https://github.com/wycats/javascript-decorators/issues/29), [another reference](https://stackoverflow.com/a/50714345/8944059)
 
 [Please look here first, to decide if it is an typegoose/mongoose issue](https://github.com/Automattic/mongoose/issues?utf8=✓&q=is%3Aissue+involves%3Ahasezoey)

--- a/github-page/_guides/known-issues.md
+++ b/github-page/_guides/known-issues.md
@@ -10,5 +10,7 @@ redirect_from:
 - ts-node: never run `ts-node --transpile-only` (seems like ts-node will not fix it)
 - typegoose dosnt work with classes that have the same name [{% include gitissue repo="hasezoey" num=23 %}, {% include gitissue repo="hasezoey" num=24 %}]
 - `@prop` cannot be applied to `get` & `set` (virtuals), because virtuals do not accept options & schema.loadClass wouldnt load these
+- in this PR: `_id: false` does not work, i dont know why
+- please make sure to use the right decorator execution order to prevent something like hook to fail if `@modelOptions` changes the name
 
 [Please look here first, to decide if it is an typegoose/mongoose issue](https://github.com/Automattic/mongoose/issues?utf8=✓&q=is%3Aissue+involves%3Ahasezoey)

--- a/src/internal/data.ts
+++ b/src/internal/data.ts
@@ -10,6 +10,10 @@ export interface PluginMap {
   mongoosePlugin(schema: Schema<any>, options: object): void;
   options: object;
 }
+export interface DecoratorCacheMap {
+  class: NewableFunction;
+  decorators: Map<string, (...args: any) => void>;
+}
 
 /** Schema Map */
 export const schemas: Map<string, SchemaDefinition> = new Map();
@@ -25,3 +29,5 @@ export const plugins: Map<string, PluginMap[]> = new Map();
 export const constructors: Map<string, NewableFunction> = new Map();
 /** Build Schemas */
 export const buildSchemas: Map<string, Schema> = new Map();
+/** Used to cache (inner-class) decorators (because of execution order) */
+export const decoratorCache: Map<string, DecoratorCacheMap> = new Map();

--- a/src/internal/data.ts
+++ b/src/internal/data.ts
@@ -27,7 +27,5 @@ export const hooks: Map<string, HooksPrePost> = new Map();
 export const plugins: Map<string, PluginMap[]> = new Map();
 /** Constructors Map */
 export const constructors: Map<string, NewableFunction> = new Map();
-/** Build Schemas */
-export const buildSchemas: Map<string, Schema> = new Map();
 /** Used to cache (inner-class) decorators (because of execution order) */
 export const decoratorCache: Map<string, DecoratorCacheMap> = new Map();

--- a/src/internal/schema.ts
+++ b/src/internal/schema.ts
@@ -3,20 +3,9 @@ import * as mongoose from 'mongoose';
 import { isNullOrUndefined } from 'util';
 import { AnyParamConstructor, EmptyVoidFn, IModelOptions } from '../types';
 import { DecoratorKeys } from './constants';
-import { buildSchemas, decoratorCache, hooks, plugins, schemas, virtuals } from './data';
+import { decoratorCache, hooks, plugins, schemas, virtuals } from './data';
 import { NoValidClass } from './errors';
 import { getName } from './utils';
-
-// /**
-//  * Apply Options to an existing Schema
-//  * @param sch
-//  * @param opt
-//  */
-// function applyOptions(sch: mongoose.Schema, opt: mongoose.SchemaOptions) {
-//   for (const [key, value] of Object.entries(opt)) {
-//     sch.set(key as keyof mongoose.SchemaOptions, value);
-//   }
-// }
 
 /**
  * Private schema builder out of class props
@@ -40,17 +29,6 @@ export function _buildSchema<T, U extends AnyParamConstructor<T>>(
   opt = isNullOrUndefined(opt) || typeof opt !== 'object' ? {} : opt;
 
   const name = getName(cl);
-  if (buildSchemas.get(name)) {
-    // this below are leftovers of trying to get "_id: false" to work
-    // if (Object.keys(opt).length > 0) {
-    //   const fsch = buildSchemas.get(name).clone();
-    //   applyOptions(fsch, opt);
-
-    //   return fsch;
-    // }
-
-    return buildSchemas.get(name);
-  }
 
   /** Simplify the usage */
   const Schema = mongoose.Schema;
@@ -109,8 +87,6 @@ export function _buildSchema<T, U extends AnyParamConstructor<T>>(
   for (const index of indices) {
     sch.index(index.fields, index.options);
   }
-
-  buildSchemas.set(name, sch);
 
   return sch;
 }

--- a/src/internal/schema.ts
+++ b/src/internal/schema.ts
@@ -5,7 +5,7 @@ import { AnyParamConstructor, EmptyVoidFn, IModelOptions } from '../types';
 import { DecoratorKeys } from './constants';
 import { decoratorCache, hooks, plugins, schemas, virtuals } from './data';
 import { NoValidClass } from './errors';
-import { getName, mergeMetadata } from './utils';
+import { getName, mergeSchemaOptions } from './utils';
 
 /**
  * Private schema builder out of class props
@@ -25,12 +25,8 @@ export function _buildSchema<T, U extends AnyParamConstructor<T>>(
     throw new NoValidClass(cl);
   }
 
-  // Option sanity check
-  opt = mergeMetadata(
-    DecoratorKeys.ModelOptions,
-    isNullOrUndefined(opt) || typeof opt !== 'object' ? {} : opt,
-    cl
-  );
+  // Options sanity check
+  opt = mergeSchemaOptions(isNullOrUndefined(opt) || typeof opt !== 'object' ? {} : opt, cl);
 
   const name = getName(cl);
 

--- a/src/internal/schema.ts
+++ b/src/internal/schema.ts
@@ -7,16 +7,16 @@ import { buildSchemas, decoratorCache, hooks, plugins, schemas, virtuals } from 
 import { NoValidClass } from './errors';
 import { getName } from './utils';
 
-/**
- * Apply Options to an existing Schema
- * @param sch
- * @param opt
- */
-function applyOptions(sch: mongoose.Schema, opt: mongoose.SchemaOptions) {
-  for (const [key, value] of Object.entries(opt)) {
-    sch.set(key as keyof mongoose.SchemaOptions, value);
-  }
-}
+// /**
+//  * Apply Options to an existing Schema
+//  * @param sch
+//  * @param opt
+//  */
+// function applyOptions(sch: mongoose.Schema, opt: mongoose.SchemaOptions) {
+//   for (const [key, value] of Object.entries(opt)) {
+//     sch.set(key as keyof mongoose.SchemaOptions, value);
+//   }
+// }
 
 /**
  * Private schema builder out of class props
@@ -75,7 +75,7 @@ export function _buildSchema<T, U extends AnyParamConstructor<T>>(
   } else {
     sch = sch.clone();
     sch.add(schemas.get(name));
-    applyOptions(sch, opt);
+    // applyOptions(sch, opt);
   }
 
   sch.loadClass(cl);

--- a/src/internal/schema.ts
+++ b/src/internal/schema.ts
@@ -11,15 +11,15 @@ import { getName } from './utils';
  * Private schema builder out of class props
  * -> If you discover this, dont use this function, use Typegoose.buildSchema!
  * @param cl The not initialized Class
- * @param name The Name to save the Schema Under (Mostly Constructor.name)
  * @param sch Already Existing Schema?
+ * @param opt Options to override
  * @returns Returns the Build Schema
  * @private
  */
 export function _buildSchema<T, U extends AnyParamConstructor<T>>(
   cl: U,
   sch?: mongoose.Schema,
-  opt: mongoose.SchemaOptions = {}
+  opt?: mongoose.SchemaOptions
 ) {
   if (typeof cl !== 'function') {
     throw new NoValidClass(cl);

--- a/src/internal/schema.ts
+++ b/src/internal/schema.ts
@@ -5,7 +5,7 @@ import { AnyParamConstructor, EmptyVoidFn, IModelOptions } from '../types';
 import { DecoratorKeys } from './constants';
 import { decoratorCache, hooks, plugins, schemas, virtuals } from './data';
 import { NoValidClass } from './errors';
-import { getName } from './utils';
+import { getName, mergeMetadata } from './utils';
 
 /**
  * Private schema builder out of class props
@@ -26,7 +26,11 @@ export function _buildSchema<T, U extends AnyParamConstructor<T>>(
   }
 
   // Option sanity check
-  opt = isNullOrUndefined(opt) || typeof opt !== 'object' ? {} : opt;
+  opt = mergeMetadata(
+    DecoratorKeys.ModelOptions,
+    isNullOrUndefined(opt) || typeof opt !== 'object' ? {} : opt,
+    cl
+  );
 
   const name = getName(cl);
 

--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -241,16 +241,13 @@ export function mergeSchemaOptions<T, U extends AnyParamConstructor<T>>(value: m
  * @param cl The Class
  */
 export function getName<T, U extends AnyParamConstructor<T>>(cl: U) {
-  // disabled until hasezoey#23 & hasezoey#24 gets fixed
+  const options: IModelOptions = Reflect.getMetadata(DecoratorKeys.ModelOptions, cl) || {};
 
-  // const options: IModelOptions = Reflect.getMetadata(DecoratorKeys.ModelOptions, cl) || {};
+  const baseName = cl.name;
+  const suffix = (options.options ? options.options.customName : undefined) ||
+    (options.schemaOptions ? options.schemaOptions.collection : undefined);
 
-  // const baseName = cl.name;
-  // const suffix = (options.options ? options.options.customName : undefined) ||
-  //   (options.schemaOptions ? options.schemaOptions.collection : undefined);
-
-  // return suffix ? `${baseName}_${suffix}` : baseName;
-  return cl.name;
+  return suffix ? `${baseName}_${suffix}` : baseName;
 }
 
 /**

--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -267,6 +267,7 @@ export function isNotDefined(cl: any) {
 
 /**
  * Assign "__uniqueID" to a class
+ * (used for the decoratorCache)
  * @param cl
  * @returns the initname to be used as identifier
  */

--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -163,13 +163,29 @@ function isModelOptions(value: unknown): value is IModelOptions {
 }
 
 /**
- * Merges existing metadata with new value
+ * Merge value & existing Metadata & Save it to the class
+ * Difference with "mergeMetadata" is that this one DOES save it to the class
  * @param key Metadata key
  * @param value Raw value
  * @param cl The constructor
  * @internal
  */
-export function assignMetadata(key: DecoratorKeys, value: unknown, cl: new () => {}): void {
+export function assignMetadata(key: DecoratorKeys, value: unknown, cl: new () => {}): any {
+  const newValue = mergeMetadata(key, value, cl);
+  Reflect.defineMetadata(key, newValue, cl);
+
+  return newValue;
+}
+
+/**
+ * Merge value & existing Metadata
+ * Difference with "assignMetadata" is that this one DOES NOT save it to the class
+ * @param key Metadata key
+ * @param value Raw value
+ * @param cl The constructor
+ * @internal
+ */
+export function mergeMetadata(key: DecoratorKeys, value: unknown, cl: new () => {}): any {
   if (typeof key !== 'string') {
     throw new TypeError(`"${key}"(key) is not a string! (assignMetadata)`);
   }
@@ -190,8 +206,7 @@ export function assignMetadata(key: DecoratorKeys, value: unknown, cl: new () =>
     value.options = Object.assign(current.options, value.options);
   }
 
-  const newValue = Object.assign(current, value);
-  Reflect.defineMetadata(key, newValue, cl);
+  return Object.assign(current, value);
 }
 
 /**

--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -230,8 +230,8 @@ export function isNotDefined(cl: any) {
  * @returns the initname to be used as identifier
  */
 export function createUniqueID(cl: any) {
-  if (!isNullOrUndefined(cl.__uniqueID)) {
-    cl._uniqueID = Date.now();
+  if (isNullOrUndefined(cl.__uniqueID)) {
+    cl.__uniqueID = Date.now();
   }
   const initname: string = `${cl.constructor.name}_${cl.__uniqueID}`;
   if (!decoratorCache.get(initname)) {

--- a/src/prop.ts
+++ b/src/prop.ts
@@ -49,7 +49,7 @@ function baseProp(
   decoratorCache.get(initname).decorators.set(key, () => {
     if (utils.isNotDefined(Type)) {
       if (Type !== target) { // prevent "infinite" buildSchema loop / Maximum Class size exceeded
-        buildSchema(Type, { schemaOptions: { _id: typeof rawOptions._id === 'boolean' ? rawOptions._id : true } });
+        buildSchema(Type, { _id: typeof rawOptions._id === 'boolean' ? rawOptions._id : true });
       }
     }
     const name: string = utils.getName(target.constructor);
@@ -268,9 +268,7 @@ function baseProp(
         return;
       case WhatIsIt.NONE:
         const virtualSchema = buildSchema(Type, {
-          schemaOptions: {
-            _id: typeof rawOptions._id === 'boolean' ? rawOptions._id : true
-          }
+          _id: typeof rawOptions._id === 'boolean' ? rawOptions._id : true
         });
         schemas.get(name)[key] = {
           ...schemas.get(name)[key],

--- a/src/prop.ts
+++ b/src/prop.ts
@@ -2,7 +2,7 @@ import * as mongoose from 'mongoose';
 
 import { isNullOrUndefined } from 'util';
 import { DecoratorKeys } from './internal/constants';
-import { schemas, virtuals } from './internal/data';
+import { decoratorCache, schemas, virtuals } from './internal/data';
 import {
   InvalidPropError,
   InvalidTypeError,
@@ -13,6 +13,7 @@ import {
 } from './internal/errors';
 import { _buildSchema } from './internal/schema';
 import * as utils from './internal/utils';
+import { buildSchema } from './typegoose';
 import {
   AnyParamConstructor,
   ArrayPropOptions,
@@ -43,234 +44,244 @@ function baseProp(
   key: string,
   whatis: WhatIsIt = WhatIsIt.NONE
 ): void {
-  const name: string = utils.getName(target.constructor);
-  rawOptions = Object.assign(rawOptions, {});
+  const initname = utils.createUniqueID(target);
 
-  if (!virtuals.get(name)) {
-    virtuals.set(name, new Map());
-  }
-
-  if (utils.isWithVirtualPOP(rawOptions)) {
-    if (!utils.includesAllVirtualPOP(rawOptions)) {
-      throw new NotAllVPOPElementsError(name, key);
+  decoratorCache.get(initname).decorators.set(key, () => {
+    if (utils.isNotDefined(Type)) {
+      if (Type !== target) { // prevent "infinite" buildSchema loop / Maximum Class size exceeded
+        buildSchema(Type);
+      }
     }
-    virtuals.get(name).set(key, rawOptions);
+    const name: string = utils.getName(target.constructor);
+    rawOptions = Object.assign(rawOptions, {});
 
-    return;
-  }
-
-  if (whatis === WhatIsIt.ARRAY) {
-    utils.initAsArray(name, key);
-  } else {
-    utils.initAsObject(name, key);
-  }
-
-  if (!isNullOrUndefined(rawOptions.set) || !isNullOrUndefined(rawOptions.get)) {
-    if (typeof rawOptions.set !== 'function') {
-      throw new TypeError(`"${name}.${key}" does not have a set function!`);
-    }
-    if (typeof rawOptions.get !== 'function') {
-      throw new TypeError(`"${name}.${key}" does not have a get function!`);
+    if (!virtuals.get(name)) {
+      virtuals.set(name, new Map());
     }
 
-    const newType = rawOptions && rawOptions.type ? rawOptions.type : Type;
-    if (rawOptions && rawOptions.type) {
-      delete rawOptions.type;
+    if (utils.isWithVirtualPOP(rawOptions)) {
+      if (!utils.includesAllVirtualPOP(rawOptions)) {
+        throw new NotAllVPOPElementsError(name, key);
+      }
+      virtuals.get(name).set(key, rawOptions);
+
+      return;
     }
-    /*
-     * Note:
-     * this dosnt have a check if prop & returntype of the function is the same, because it cant be accessed at runtime
-     */
-    schemas.get(name)[key] = {
-      ...schemas.get(name)[key],
-      type: newType,
-      ...rawOptions
-    };
 
-    return;
-  }
-
-  const ref = rawOptions.ref;
-  const refType = rawOptions.refType || mongoose.Schema.Types.ObjectId;
-  if (ref) {
-    delete rawOptions.ref;
-    schemas.get(name)[key] = {
-      ...schemas.get(name)[key],
-      type: refType,
-      ref: typeof ref === 'string' ? ref : ref.name,
-      ...rawOptions
-    };
-
-    return;
-  }
-
-  const itemsRef = rawOptions.itemsRef;
-  const itemsRefType = rawOptions.itemsRefType || mongoose.Schema.Types.ObjectId;
-  if (itemsRef) {
-    delete rawOptions.itemsRef;
-    schemas.get(name)[key][0] = {
-      ...schemas.get(name)[key][0],
-      type: itemsRefType,
-      ref: typeof itemsRef === 'string' ? itemsRef : itemsRef.name,
-      ...rawOptions
-    };
-
-    return;
-  }
-
-  const refPath = rawOptions.refPath;
-  if (refPath && typeof refPath === 'string') {
-    delete rawOptions.refPath;
-    schemas.get(name)[key] = {
-      ...schemas.get(name)[key],
-      type: itemsRefType,
-      refPath,
-      ...rawOptions
-    };
-
-    return;
-  }
-
-  const itemsRefPath = rawOptions.itemsRefPath;
-  if (itemsRefPath && typeof itemsRefPath === 'string') {
-    delete rawOptions.itemsRefPath;
-    schemas.get(name)[key][0] = {
-      ...schemas.get(name)[key][0],
-      type: itemsRefType,
-      refPath: itemsRefPath,
-      ...rawOptions
-    };
-
-    return;
-  }
-
-  const enumOption = rawOptions.enum;
-  if (enumOption) {
-    if (!Array.isArray(enumOption)) {
-      rawOptions.enum = Object.keys(enumOption).map((propKey) => enumOption[propKey]);
+    if (whatis === WhatIsIt.ARRAY) {
+      utils.initAsArray(name, key);
+    } else {
+      utils.initAsObject(name, key);
     }
-  }
 
-  const selectOption = rawOptions.select;
-  if (typeof selectOption === 'boolean') {
-    schemas.get(name)[key] = {
-      ...schemas.get(name)[key],
-      select: selectOption
-    };
-  }
+    if (!isNullOrUndefined(rawOptions.set) || !isNullOrUndefined(rawOptions.get)) {
+      if (typeof rawOptions.set !== 'function') {
+        throw new TypeError(`"${name}.${key}" does not have a set function!`);
+      }
+      if (typeof rawOptions.get !== 'function') {
+        throw new TypeError(`"${name}.${key}" does not have a get function!`);
+      }
 
-  // check if Type is actually a real working Type
-  if (isNullOrUndefined(Type) || typeof Type !== 'function') {
-    throw new InvalidTypeError(target.name, key, Type);
-  }
+      const newType = rawOptions && rawOptions.type ? rawOptions.type : Type;
+      if (rawOptions && rawOptions.type) {
+        delete rawOptions.type;
+      }
+      /*
+       * Note:
+       * this dosnt have a check if prop & returntype of the function is the same,
+       * because it cant be accessed at runtime
+       */
+      schemas.get(name)[key] = {
+        ...schemas.get(name)[key],
+        type: newType,
+        ...rawOptions
+      };
 
-  // check for validation inconsistencies
-  if (utils.isWithStringValidate(rawOptions) && !utils.isString(Type)) {
-    throw new NotStringTypeError(key);
-  }
+      return;
+    }
 
-  // check for transform inconsistencies
-  if (utils.isWithStringTransform(rawOptions) && !utils.isString(Type)) {
-    throw new NotStringTypeError(key);
-  }
+    const ref = rawOptions.ref;
+    const refType = rawOptions.refType || mongoose.Schema.Types.ObjectId;
+    if (ref) {
+      delete rawOptions.ref;
+      schemas.get(name)[key] = {
+        ...schemas.get(name)[key],
+        type: refType,
+        ref: typeof ref === 'string' ? ref : ref.name,
+        ...rawOptions
+      };
 
-  if (utils.isWithNumberValidate(rawOptions) && !utils.isNumber(Type)) {
-    throw new NotNumberTypeError(key);
-  }
+      return;
+    }
 
-  const subSchema = schemas.get(Type.name);
-  if (!subSchema && !utils.isPrimitive(Type) && !utils.isObject(Type)) {
-    throw new InvalidPropError(Type.name, key); // This seems to be never thrown!
-  }
+    const itemsRef = rawOptions.itemsRef;
+    const itemsRefType = rawOptions.itemsRefType || mongoose.Schema.Types.ObjectId;
+    if (itemsRef) {
+      delete rawOptions.itemsRef;
+      schemas.get(name)[key][0] = {
+        ...schemas.get(name)[key][0],
+        type: itemsRefType,
+        ref: typeof itemsRef === 'string' ? itemsRef : itemsRef.name,
+        ...rawOptions
+      };
 
-  const { ['items']: items, ...options } = rawOptions;
-  if (utils.isPrimitive(Type)) {
+      return;
+    }
+
+    const refPath = rawOptions.refPath;
+    if (refPath && typeof refPath === 'string') {
+      delete rawOptions.refPath;
+      schemas.get(name)[key] = {
+        ...schemas.get(name)[key],
+        type: itemsRefType,
+        refPath,
+        ...rawOptions
+      };
+
+      return;
+    }
+
+    const itemsRefPath = rawOptions.itemsRefPath;
+    if (itemsRefPath && typeof itemsRefPath === 'string') {
+      delete rawOptions.itemsRefPath;
+      schemas.get(name)[key][0] = {
+        ...schemas.get(name)[key][0],
+        type: itemsRefType,
+        refPath: itemsRefPath,
+        ...rawOptions
+      };
+
+      return;
+    }
+
+    const enumOption = rawOptions.enum;
+    if (enumOption) {
+      if (!Array.isArray(enumOption)) {
+        rawOptions.enum = Object.keys(enumOption).map((propKey) => enumOption[propKey]);
+      }
+    }
+
+    const selectOption = rawOptions.select;
+    if (typeof selectOption === 'boolean') {
+      schemas.get(name)[key] = {
+        ...schemas.get(name)[key],
+        select: selectOption
+      };
+    }
+
+    // check if Type is actually a real working Type
+    if (isNullOrUndefined(Type) || typeof Type !== 'function') {
+      throw new InvalidTypeError(target.name, key, Type);
+    }
+
+    // check for validation inconsistencies
+    if (utils.isWithStringValidate(rawOptions) && !utils.isString(Type)) {
+      throw new NotStringTypeError(key);
+    }
+
+    // check for transform inconsistencies
+    if (utils.isWithStringTransform(rawOptions) && !utils.isString(Type)) {
+      throw new NotStringTypeError(key);
+    }
+
+    if (utils.isWithNumberValidate(rawOptions) && !utils.isNumber(Type)) {
+      throw new NotNumberTypeError(key);
+    }
+
+    const subSchema = schemas.get(utils.getName(Type));
+    if (!subSchema && !utils.isPrimitive(Type) && !utils.isObject(Type)) {
+      throw new InvalidPropError(Type.name, key); // This seems to be never thrown!
+    }
+
+    const { ['items']: items, ...options } = rawOptions;
+    if (utils.isPrimitive(Type)) {
+      switch (whatis) {
+        case WhatIsIt.ARRAY:
+          schemas.get(name)[key] = {
+            ...schemas.get(name)[key][0],
+            ...options,
+            type: [Type]
+          };
+
+          return;
+        case WhatIsIt.MAP:
+          // "default" is a reserved keyword, thats why "_default" is used
+          const { default: _default }: PropOptions = options;
+          delete options.default;
+          delete options.of;
+          schemas.get(name)[key] = {
+            ...schemas.get(name)[key],
+            type: Map,
+            default: _default,
+            of: { type: Type, ...options }
+          };
+
+          return;
+        case WhatIsIt.NONE:
+          schemas.get(name)[key] = {
+            ...schemas.get(name)[key],
+            ...options,
+            type: Type
+          };
+
+          return;
+        default:
+          throw new Error(`"${whatis}"(whatis(primitive)) is invalid for "${name}.${key}"`);
+      }
+    }
+
+    // If the 'Type' is not a 'Primitive Type' and no subschema was found treat the type as 'Object'
+    // so that mongoose can store it as nested document
+    if (utils.isObject(Type) && !subSchema) {
+      schemas.get(name)[key] = {
+        ...schemas.get(name)[key],
+        ...options,
+        type: Object // i think this could take some improvements
+      };
+
+      return;
+    }
+
     switch (whatis) {
       case WhatIsIt.ARRAY:
         schemas.get(name)[key] = {
-          ...schemas.get(name)[key][0],
+          ...schemas.get(name)[key][0], // [0] is needed, because "initasArray" adds this (empty)
           ...options,
-          type: [Type]
+          type: [{
+            ...(typeof options._id === 'boolean' ? { _id: options._id } : {}),
+            ...subSchema
+          }]
         };
 
         return;
       case WhatIsIt.MAP:
-        // "default" is a reserved keyword, thats why "_default" is used
-        const { default: _default }: PropOptions = options;
-        delete options.default;
-        delete options.of;
         schemas.get(name)[key] = {
           ...schemas.get(name)[key],
           type: Map,
-          default: _default,
-          of: { type: Type, ...options }
+          ...options
+        };
+        (schemas.get(name)[key] as mongoose.SchemaTypeOpts<Map<any, any>>).of = {
+          ...(schemas.get(name)[key] as mongoose.SchemaTypeOpts<Map<any, any>>).of,
+          ...subSchema
         };
 
         return;
       case WhatIsIt.NONE:
+        const virtualSchema = buildSchema(Type);
+        // these below are leftovers of trying to get "_id: false" to work
+        // virtualSchema.set('_id', typeof rawOptions._id === 'boolean' ? rawOptions._id : false);
+        // virtualSchema.set('id', typeof rawOptions._id === 'boolean' ? rawOptions._id : false);
         schemas.get(name)[key] = {
           ...schemas.get(name)[key],
           ...options,
-          type: Type
+          type: virtualSchema
         };
 
         return;
       default:
-        throw new Error(`"${whatis}"(whatis(primitive)) is invalid for "${name}.${key}"`);
+        throw new Error(`"${whatis}"(whatis(subSchema)) is invalid for "${name}.${key}"`);
     }
-  }
-
-  // If the 'Type' is not a 'Primitive Type' and no subschema was found treat the type as 'Object'
-  // so that mongoose can store it as nested document
-  if (utils.isObject(Type) && !subSchema) {
-    schemas.get(name)[key] = {
-      ...schemas.get(name)[key],
-      ...options,
-      type: Object // i think this could take some improvements
-    };
-
-    return;
-  }
-
-  switch (whatis) {
-    case WhatIsIt.ARRAY:
-      schemas.get(name)[key] = {
-        ...schemas.get(name)[key][0], // [0] is needed, because "initasArray" adds this (empty)
-        ...options,
-        type: [{
-          ...(typeof options._id === 'boolean' ? { _id: options._id } : {}),
-          ...subSchema
-        }]
-      };
-
-      return;
-    case WhatIsIt.MAP:
-      schemas.get(name)[key] = {
-        ...schemas.get(name)[key],
-        type: Map,
-        ...options
-      };
-      (schemas.get(name)[key] as mongoose.SchemaTypeOpts<Map<any, any>>).of = {
-        ...(schemas.get(name)[key] as mongoose.SchemaTypeOpts<Map<any, any>>).of,
-        ...subSchema
-      };
-
-      return;
-    case WhatIsIt.NONE:
-      const virtualSchema = _buildSchema(
-        Type,
-        null,
-        { _id: typeof rawOptions._id === 'boolean' ? rawOptions._id : true });
-      schemas.get(name)[key] = {
-        ...schemas.get(name)[key],
-        ...options,
-        type: virtualSchema
-      };
-
-      return;
-    default:
-      throw new Error(`"${whatis}"(whatis(subSchema)) is invalid for "${name}.${key}"`);
-  }
+  });
 }
 
 /**

--- a/src/prop.ts
+++ b/src/prop.ts
@@ -49,7 +49,7 @@ function baseProp(
   decoratorCache.get(initname).decorators.set(key, () => {
     if (utils.isNotDefined(Type)) {
       if (Type !== target) { // prevent "infinite" buildSchema loop / Maximum Class size exceeded
-        buildSchema(Type);
+        buildSchema(Type, { schemaOptions: { _id: typeof rawOptions._id === 'boolean' ? rawOptions._id : true } });
       }
     }
     const name: string = utils.getName(target.constructor);
@@ -267,10 +267,11 @@ function baseProp(
 
         return;
       case WhatIsIt.NONE:
-        const virtualSchema = buildSchema(Type);
-        // these below are leftovers of trying to get "_id: false" to work
-        // virtualSchema.set('_id', typeof rawOptions._id === 'boolean' ? rawOptions._id : false);
-        // virtualSchema.set('id', typeof rawOptions._id === 'boolean' ? rawOptions._id : false);
+        const virtualSchema = buildSchema(Type, {
+          schemaOptions: {
+            _id: typeof rawOptions._id === 'boolean' ? rawOptions._id : true
+          }
+        });
         schemas.get(name)[key] = {
           ...schemas.get(name)[key],
           ...options,

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -5,7 +5,7 @@ import 'reflect-metadata';
 import { deprecate } from 'util';
 import * as defaultClasses from './defaultClasses';
 import { DecoratorKeys } from './internal/constants';
-import { buildSchemas, constructors, models } from './internal/data';
+import { constructors, models } from './internal/data';
 import { NoValidClass } from './internal/errors';
 import { _buildSchema } from './internal/schema';
 import { assignMetadata, getName } from './internal/utils';
@@ -116,9 +116,6 @@ export function buildSchema<T, U extends AnyParamConstructor<T>>(cl: U) {
     throw new NoValidClass(cl);
   }
 
-  if (buildSchemas.get(getName(cl))) {
-    return buildSchemas.get(getName(cl));
-  }
   let sch: mongoose.Schema<U>;
   /** Parent Constructor */
   let parentCtor = Object.getPrototypeOf(cl.prototype).constructor;

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -68,14 +68,14 @@ export abstract class Typegoose {
  * const NameModel = getModelForClass(Name);
  * ```
  */
-export function getModelForClass<T, U extends AnyParamConstructor<T>>(cl: U, settings?: IModelOptions) {
+export function getModelForClass<T, U extends AnyParamConstructor<T>>(cl: U, options?: IModelOptions) {
   if (typeof cl !== 'function') {
     throw new NoValidClass(cl);
   }
 
-  assignMetadata(DecoratorKeys.ModelOptions, settings, cl);
+  assignMetadata(DecoratorKeys.ModelOptions, options, cl);
 
-  const options: IModelOptions = Reflect.getMetadata(DecoratorKeys.ModelOptions, cl) || {};
+  const roptions: IModelOptions = Reflect.getMetadata(DecoratorKeys.ModelOptions, cl) || {};
   const name = getName(cl);
 
   if (models.get(name)) {
@@ -83,10 +83,10 @@ export function getModelForClass<T, U extends AnyParamConstructor<T>>(cl: U, set
   }
 
   let model = mongoose.model.bind(mongoose);
-  if (options.existingConnection) {
-    model = options.existingConnection.model.bind(options.existingConnection);
-  } else if (options.existingMongoose) {
-    model = options.existingMongoose.model.bind(options.existingMongoose);
+  if (roptions.existingConnection) {
+    model = roptions.existingConnection.model.bind(roptions.existingConnection);
+  } else if (roptions.existingMongoose) {
+    model = roptions.existingMongoose.model.bind(roptions.existingMongoose);
   }
 
   return addModelToTypegoose(model(name, buildSchema(cl)), cl);
@@ -111,10 +111,12 @@ export function setModelForClass<T, U extends AnyParamConstructor<T>>(cl: U) {
  * @param cl The not initialized Class
  * @returns Returns the Build Schema
  */
-export function buildSchema<T, U extends AnyParamConstructor<T>>(cl: U) {
+export function buildSchema<T, U extends AnyParamConstructor<T>>(cl: U, options?: IModelOptions) {
   if (typeof cl !== 'function') {
     throw new NoValidClass(cl);
   }
+
+  assignMetadata(DecoratorKeys.ModelOptions, options, cl);
 
   let sch: mongoose.Schema<U>;
   /** Parent Constructor */

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -8,7 +8,7 @@ import { DecoratorKeys } from './internal/constants';
 import { constructors, models } from './internal/data';
 import { NoValidClass } from './internal/errors';
 import { _buildSchema } from './internal/schema';
-import { assignMetadata, getName, mergeMetadata } from './internal/utils';
+import { assignMetadata, getName, mergeMetadata, mergeSchemaOptions } from './internal/utils';
 import { AnyParamConstructor, DocumentType, IModelOptions, Ref, ReturnModelType } from './types';
 
 /* exports */
@@ -87,7 +87,7 @@ export function getModelForClass<T, U extends AnyParamConstructor<T>>(cl: U, opt
     model = roptions.existingMongoose.model.bind(roptions.existingMongoose);
   }
 
-  return addModelToTypegoose(model(name, buildSchema(cl)), cl);
+  return addModelToTypegoose(model(name, buildSchema(cl, roptions.schemaOptions)), cl);
 }
 
 /* istanbul ignore next */
@@ -109,12 +109,12 @@ export function setModelForClass<T, U extends AnyParamConstructor<T>>(cl: U) {
  * @param cl The not initialized Class
  * @returns Returns the Build Schema
  */
-export function buildSchema<T, U extends AnyParamConstructor<T>>(cl: U, options?: IModelOptions) {
+export function buildSchema<T, U extends AnyParamConstructor<T>>(cl: U, options?: mongoose.SchemaOptions) {
   if (typeof cl !== 'function') {
     throw new NoValidClass(cl);
   }
 
-  const mergedOptions = mergeMetadata(DecoratorKeys.ModelOptions, options, cl);
+  const mergedOptions = mergeSchemaOptions(options, cl);
 
   let sch: mongoose.Schema<U>;
   /** Parent Constructor */

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2,12 +2,12 @@ import { use } from 'chai';
 import * as cap from 'chai-as-promised';
 
 import { suite as BigUserTest } from './tests/biguser.test';
+import { suite as customNameTests } from './tests/customName.test';
 import { suite as IndexTests } from './tests/dbIndex.test';
 import { suite as DefaultClassesTests } from './tests/dClasses.test';
 import { suite as ErrorTests } from './tests/errors.test';
 import { suite as GCFDTest } from './tests/getClassForDocument.test';
 import { suite as HookTest } from './tests/hooks.test';
-// import { suite as OptionTests } from './tests/options.test';
 import { suite as RefTest } from './tests/ref.test';
 import { suite as ShouldAddTest } from './tests/shouldAdd.test';
 import { suite as ShouldRunTests } from './tests/shouldRun.test';
@@ -44,6 +44,5 @@ describe('Typegoose', () => {
 
   describe('Ref tests', RefTest.bind(this));
 
-  // The Test Suite is disabled until hasezoey#23 & hasezoey#24 gets fixed
-  // describe('@modelOptions', OptionTests.bind(this));
+  describe('customName', customNameTests.bind(this));
 });

--- a/test/models/job.ts
+++ b/test/models/job.ts
@@ -1,5 +1,6 @@
-import { prop } from '../../src/typegoose';
+import { modelOptions, prop } from '../../src/typegoose';
 
+@modelOptions({ schemaOptions: { _id: false } })
 export class JobType {
   @prop({ required: true })
   public field: string;
@@ -8,6 +9,7 @@ export class JobType {
   public salery: number;
 }
 
+@modelOptions({ schemaOptions: { _id: false } })
 export class Job {
   @prop()
   public title?: string;

--- a/test/models/nestedObject.ts
+++ b/test/models/nestedObject.ts
@@ -1,22 +1,20 @@
 import { arrayProp, getModelForClass, prop } from '../../src/typegoose';
 
 export class AddressNested {
+  @prop()
   public street: string;
-
-  constructor(street: string) {
-    this.street = street;
-  }
 }
 
 export class PersonNested {
   @prop()
   public name: string;
 
-  @prop()
+  @prop({ _id: false })
   public address: AddressNested;
 
-  @arrayProp({ items: AddressNested })
+  @arrayProp({ _id: false, items: AddressNested })
   public moreAddresses: AddressNested[];
 }
 
 export const PersonNestedModel = getModelForClass(PersonNested);
+export const AddressNestedModel = getModelForClass(AddressNested);

--- a/test/models/user.ts
+++ b/test/models/user.ts
@@ -68,7 +68,7 @@ export class User {
   @arrayProp({ items: String, required: true })
   public languages: string[];
 
-  @arrayProp({ items: Job })
+  @arrayProp({ items: Job, _id: false })
   public previousJobs?: Job[];
 
   @arrayProp({ itemsRef: Car })
@@ -91,7 +91,7 @@ export class User {
     return this.save();
   }
 
-  public async addJob(this: DocumentType<User>, job: Partial<Job> = {}) {
+  public async addJob(this: DocumentType<User>, job: Job = {}) {
     this.previousJobs.push(job);
 
     return this.save();

--- a/test/tests/biguser.test.ts
+++ b/test/tests/biguser.test.ts
@@ -78,7 +78,9 @@ export function suite() {
       expect(foundUser.job).to.have.property('position', 'Lead');
       expect(foundUser.job).to.have.property('startedAt').to.be.instanceof(Date);
       expect(foundUser.job.titleInUppercase()).to.equal('Developer'.toUpperCase());
-      expect(foundUser.job.jobType).to.not.have.property('_id');
+      // these below are disabled because of https://github.com/Automattic/mongoose/issues/8137
+      // console.log('hi', schemas.get(getName(Job)));
+      // expect(foundUser.job.jobType).to.not.have.property('_id');
       expect(foundUser.job.jobType).to.have.property('salery', 5000);
       expect(foundUser.job.jobType).to.have.property('field', 'IT');
       expect(foundUser.job.jobType).to.have.property('salery').to.be.a('number');

--- a/test/tests/biguser.test.ts
+++ b/test/tests/biguser.test.ts
@@ -80,7 +80,7 @@ export function suite() {
       expect(foundUser.job.titleInUppercase()).to.equal('Developer'.toUpperCase());
       // these below are disabled because of https://github.com/Automattic/mongoose/issues/8137
       // console.log('hi', schemas.get(getName(Job)));
-      // expect(foundUser.job.jobType).to.not.have.property('_id');
+      expect(foundUser.job.jobType).to.not.have.property('_id');
       expect(foundUser.job.jobType).to.have.property('salery', 5000);
       expect(foundUser.job.jobType).to.have.property('field', 'IT');
       expect(foundUser.job.jobType).to.have.property('salery').to.be.a('number');

--- a/test/tests/biguser.test.ts
+++ b/test/tests/biguser.test.ts
@@ -78,8 +78,6 @@ export function suite() {
       expect(foundUser.job).to.have.property('position', 'Lead');
       expect(foundUser.job).to.have.property('startedAt').to.be.instanceof(Date);
       expect(foundUser.job.titleInUppercase()).to.equal('Developer'.toUpperCase());
-      // these below are disabled because of https://github.com/Automattic/mongoose/issues/8137
-      // console.log('hi', schemas.get(getName(Job)));
       expect(foundUser.job.jobType).to.not.have.property('_id');
       expect(foundUser.job.jobType).to.have.property('salery', 5000);
       expect(foundUser.job.jobType).to.have.property('field', 'IT');

--- a/test/tests/customName.test.ts
+++ b/test/tests/customName.test.ts
@@ -1,17 +1,15 @@
 import { expect } from 'chai';
 
-import { getClassForDocument, getModelForClass, modelOptions } from '../../src/typegoose';
-
-// This Test Suite is disabled until hasezoey#23 & hasezoey#24 gets fixed
+import { getClassForDocument, getModelForClass, modelOptions, prop } from '../../src/typegoose';
 
 /**
  * Function to pass into describe
  * ->Important: you need to always bind this
  * @example
  * ```
- * import { suite as OptionTests } from './options.test'
+ * import { suite as customNameTests } from './options.test'
  * ...
- * describe('@modelOptions', OptionTests.bind(this));
+ * describe('customName', customNameTests.bind(this));
  * ...
  * ```
  */
@@ -63,7 +61,7 @@ export function suite() {
     expect(gotClass).to.equals(BothOptions);
   });
 
-  it('create multiple models depending on options', () => {
+  it('create multiple models depending on options with base class (extends)', () => {
     class MultiModelBase { }
 
     {
@@ -85,6 +83,57 @@ export function suite() {
       expect(model.modelName).to.be.equal('MultiModel_SomethingDifferent');
 
       const doc = new model();
+      const gotClass = getClassForDocument(doc);
+      expect(gotClass).to.equals(MultiModel);
+    }
+  });
+
+  it('create multiple models depending on options without base model', () => {
+    {
+      @modelOptions({ schemaOptions: { collection: 'SomethingNoExtend' } })
+      class MultiModel {
+        @prop({ default: '1' })
+        public t1: string;
+
+        @prop({ default: '2' })
+        public t2: string;
+      }
+
+      const model = getModelForClass(MultiModel);
+      expect(model.modelName).to.be.equal('MultiModel_SomethingNoExtend');
+
+      const doc = new model();
+
+      expect(doc).to.not.be.an('undefined');
+      expect(doc.t1).to.equal('1');
+      expect(doc.t2).to.equal('2');
+      expect(doc).to.not.have.property('t3');
+      expect(doc).to.not.have.property('t4');
+
+      const gotClass = getClassForDocument(doc);
+      expect(gotClass).to.equals(MultiModel);
+    }
+    {
+      @modelOptions({ schemaOptions: { collection: 'SomethingDifferentNoExtend' } })
+      class MultiModel {
+        @prop({ default: '3' })
+        public t3: string;
+
+        @prop({ default: '4' })
+        public t4: string;
+      }
+
+      const model = getModelForClass(MultiModel);
+      expect(model.modelName).to.be.equal('MultiModel_SomethingDifferentNoExtend');
+
+      const doc = new model();
+
+      expect(doc).to.not.be.an('undefined');
+      expect(doc).to.not.have.property('t1');
+      expect(doc).to.not.have.property('t2');
+      expect(doc.t3).to.equal('3');
+      expect(doc.t4).to.equal('4');
+
       const gotClass = getClassForDocument(doc);
       expect(gotClass).to.equals(MultiModel);
     }

--- a/test/tests/errors.test.ts
+++ b/test/tests/errors.test.ts
@@ -225,7 +225,7 @@ export function suite() {
     it('should error if no valid type is supplied to "@mapProp" [InvalidTypeError]', () => {
       try {
         class TestInvalidTypeError {
-          @mapProp({ items: undefined })
+          @mapProp({ of: undefined })
           public something: undefined;
         }
         getModelForClass(TestInvalidTypeError);

--- a/test/tests/errors.test.ts
+++ b/test/tests/errors.test.ts
@@ -211,11 +211,11 @@ export function suite() {
 
     it('should error if no valid type is supplied to "@arrayProp" [InvalidTypeError]', () => {
       try {
-        class TestInvalidTypeError {
+        class TestInvalidTypeErrorAP {
           @arrayProp({ items: undefined })
           public something: undefined;
         }
-        getModelForClass(TestInvalidTypeError);
+        getModelForClass(TestInvalidTypeErrorAP);
         assert.fail('Expected to throw "InvalidTypeError"');
       } catch (err) {
         expect(err).to.be.an.instanceOf(InvalidTypeError);
@@ -224,11 +224,11 @@ export function suite() {
 
     it('should error if no valid type is supplied to "@mapProp" [InvalidTypeError]', () => {
       try {
-        class TestInvalidTypeError {
+        class TestInvalidTypeErrorMP {
           @mapProp({ of: undefined })
           public something: undefined;
         }
-        getModelForClass(TestInvalidTypeError);
+        getModelForClass(TestInvalidTypeErrorMP);
         assert.fail('Expected to throw "InvalidTypeError"');
       } catch (err) {
         expect(err).to.be.an.instanceOf(InvalidTypeError);

--- a/test/tests/errors.test.ts
+++ b/test/tests/errors.test.ts
@@ -12,7 +12,7 @@ import {
   NoValidClass
 } from '../../src/internal/errors';
 import { _buildSchema } from '../../src/internal/schema';
-import { assignMetadata } from '../../src/internal/utils';
+import { assignMetadata, mergeSchemaOptions } from '../../src/internal/utils';
 import { arrayProp, mapProp, prop } from '../../src/prop';
 import { addModelToTypegoose, buildSchema, getModelForClass } from '../../src/typegoose';
 
@@ -249,7 +249,7 @@ export function suite() {
       }
     });
 
-    it('should error if no valid key is supplied [NoValidClass]', () => {
+    it('should error if no valid class is supplied [NoValidClass]', () => {
       try {
         // @ts-ignore
         assignMetadata(DecoratorKeys.Index, {}, true);
@@ -258,5 +258,15 @@ export function suite() {
         expect(err).to.be.an.instanceOf(NoValidClass);
       }
     });
+  });
+
+  it('should error if no valid class is supplied to "mergeSchemaOptions" [NoValidClass]', () => {
+    try {
+      // @ts-ignore
+      mergeSchemaOptions({}, true);
+      assert.fail('Expected to throw "NoValidClass"');
+    } catch (err) {
+      expect(err).to.be.an.instanceOf(NoValidClass);
+    }
   });
 }

--- a/test/tests/errors.test.ts
+++ b/test/tests/errors.test.ts
@@ -33,10 +33,11 @@ import { addModelToTypegoose, buildSchema, getModelForClass } from '../../src/ty
 export function suite() {
   it('should error if type is not string and a transform is supplied [NotStringTypeError]', () => {
     try {
-      class TEST {
+      class TestNSTETransform {
         @prop({ lowercase: true })
         public test: number;
       }
+      getModelForClass(TestNSTETransform);
       assert.fail('Expected to throw "NotStringTypeError"');
     } catch (err) {
       expect(err).to.be.an.instanceOf(NotStringTypeError);
@@ -45,10 +46,11 @@ export function suite() {
 
   it('should error if type is not string and a validate is supplied [NotStringTypeError]', () => {
     try {
-      class TEST {
+      class TestNSTEValidate {
         @prop({ maxlength: 10 })
         public test: number;
       }
+      getModelForClass(TestNSTEValidate);
       assert.fail('Expected to throw "NotStringTypeError"');
     } catch (err) {
       expect(err).to.be.an.instanceOf(NotStringTypeError);
@@ -57,10 +59,11 @@ export function suite() {
 
   it('should error if type is not number and a validate is supplied [NotNumberTypeError]', () => {
     try {
-      class TEST {
+      class TestNNTEValidate {
         @prop({ max: 10 })
         public test: string;
       }
+      getModelForClass(TestNNTEValidate);
       assert.fail('Expected to throw "NotNumberTypeError"');
     } catch (err) {
       expect(err).to.be.an.instanceOf(NotNumberTypeError);
@@ -69,10 +72,11 @@ export function suite() {
 
   it('should error if an non-existing(runtime) type is given [NoMetadataError]', () => {
     try {
-      class TEST {
+      class TestNME {
         @prop()
         public test: undefined;
       }
+      getModelForClass(TestNME);
       assert.fail('Expected to throw "InvalidPropError"');
     } catch (err) {
       expect(err).to.be.an.instanceOf(NoMetadataError);
@@ -84,48 +88,52 @@ export function suite() {
       // ignore that it is not written right, it should be tested so
       // @ts-ignore
       @pre<Test>('')
-      class TEST {
+      class TestNoFunctionHook {
         @prop()
         public test: string;
       }
+      getModelForClass(TestNoFunctionHook);
       assert.fail('Expected to throw "TypeError"');
     } catch (err) {
       expect(err).to.be.an.instanceOf(TypeError);
-      expect((err as TypeError).message).to.be.equals(`"TEST.pre."'s function is not a function!`);
+      expect((err as TypeError).message).to.be.equals(`"TestNoFunctionHook.pre."'s function is not a function!`);
     }
   });
 
   it('should error if no get or set function is defined for non-virtuals [TypeError]', () => {
     try {
-      class TEST {
+      class TestNoGetNoSet {
         // @ts-ignore
         @prop({ set: false })
         public test: string;
       }
+      getModelForClass(TestNoGetNoSet);
       assert.fail('Expected to throw "TypeError"');
     } catch (err) {
       expect(err).to.be.an.instanceOf(TypeError);
-      expect((err as TypeError).message).to.be.equals(`"TEST.test" does not have a set function!`);
+      expect((err as TypeError).message).to.be.equals(`"TestNoGetNoSet.test" does not have a set function!`);
     }
     try {
-      class TEST {
+      class TestWrongGetSetType {
         // @ts-ignore
         @prop({ set: () => undefined, get: false })
         public test: string;
       }
+      getModelForClass(TestWrongGetSetType);
       assert.fail('Expected to throw "TypeError"');
     } catch (err) {
       expect(err).to.be.an.instanceOf(TypeError);
-      expect((err as TypeError).message).to.be.equals(`"TEST.test" does not have a get function!`);
+      expect((err as TypeError).message).to.be.equals(`"TestWrongGetSetType.test" does not have a get function!`);
     }
   });
 
   it('should error if not all needed parameters for virtual-populate are given [NotAllElementsError]', () => {
     try {
-      class TEST {
+      class TestNAEEVirtualPopulate {
         @prop({ localField: true })
         public test: string;
       }
+      getModelForClass(TestNAEEVirtualPopulate);
       assert.fail('Expected to throw "NotAllElementsError"');
     } catch (err) {
       expect(err).to.be.an.instanceOf(NotAllVPOPElementsError);

--- a/test/tests/errors.test.ts
+++ b/test/tests/errors.test.ts
@@ -215,6 +215,7 @@ export function suite() {
           @arrayProp({ items: undefined })
           public something: undefined;
         }
+        getModelForClass(TestInvalidTypeError);
         assert.fail('Expected to throw "InvalidTypeError"');
       } catch (err) {
         expect(err).to.be.an.instanceOf(InvalidTypeError);
@@ -227,6 +228,7 @@ export function suite() {
           @mapProp({ items: undefined })
           public something: undefined;
         }
+        getModelForClass(TestInvalidTypeError);
         assert.fail('Expected to throw "InvalidTypeError"');
       } catch (err) {
         expect(err).to.be.an.instanceOf(InvalidTypeError);

--- a/test/tests/getClassForDocument.test.ts
+++ b/test/tests/getClassForDocument.test.ts
@@ -6,7 +6,7 @@ import { getClassForDocument } from '../../src/internal/utils';
 import { Genders } from '../enums/genders';
 import { Car as CarType, model as Car } from '../models/car';
 import { model as InternetUser } from '../models/internetUser';
-import { AddressNested, PersonNested, PersonNestedModel } from '../models/nestedObject';
+import { AddressNested, AddressNestedModel, PersonNested, PersonNestedModel } from '../models/nestedObject';
 import { model as Person } from '../models/person';
 import { model as User, User as UserType } from '../models/user';
 
@@ -71,15 +71,14 @@ export function suite() {
   });
 
   it('should store nested address', async () => {
-    const personInput = new PersonNested();
-    personInput.name = 'Person, Some';
-    personInput.address = new AddressNested('A Street 1');
-    personInput.moreAddresses = [
-      new AddressNested('A Street 2'),
-      new AddressNested('A Street 3')
-    ];
-
-    const person = await PersonNestedModel.create(personInput);
+    const person = await PersonNestedModel.create({
+      name: 'Person, Some',
+      address: new AddressNestedModel({ street: 'A Street 1' } as AddressNested),
+      moreAddresses: [
+        new AddressNestedModel({ street: 'A Street 2' } as AddressNested),
+        new AddressNestedModel({ street: 'A Street 3' } as AddressNested)
+      ]
+    } as PersonNested);
 
     expect(person).is.not.be.an('undefined');
     expect(person.name).equals('Person, Some');

--- a/test/tests/shouldRun.test.ts
+++ b/test/tests/shouldRun.test.ts
@@ -173,18 +173,18 @@ export function suite() {
     expect(reflected.schemaOptions).to.have.property('_id', true);
   });
 
-  it('TEST', async () => {
-    class Nested {
+  it('should make use of "@prop({ _id: false })" and have no _id', async () => {
+    class TestidFalseNested {
       @prop()
       public hi: number;
     }
-    class TestClass {
+    class TestidFalse {
       @prop({ _id: false })
-      public someprop: Nested;
+      public someprop: TestidFalseNested;
     }
 
-    const model = getModelForClass(TestClass);
-    const doc = await model.create({ someprop: { hi: 10 } } as TestClass);
+    const model = getModelForClass(TestidFalse);
+    const doc = await model.create({ someprop: { hi: 10 } } as TestidFalse);
 
     expect(doc).to.not.be.an('undefined');
     expect(doc.someprop).to.have.property('hi', 10);

--- a/test/tests/shouldRun.test.ts
+++ b/test/tests/shouldRun.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import * as mongoose from 'mongoose';
 import { DecoratorKeys } from '../../src/internal/constants';
-import { assignMetadata } from '../../src/internal/utils';
+import { assignMetadata, mergeMetadata, mergeSchemaOptions } from '../../src/internal/utils';
 import {
   addModelToTypegoose,
   arrayProp,
@@ -148,11 +148,24 @@ export function suite() {
     expect(reflected).to.have.property('testOption', 'hello');
   });
 
-  it('should just run with an non existing value in assignMetadata', () => {
+  it('should just run with an non existing value in "assignMetadata"', () => {
     class Dummy { }
     assignMetadata(DecoratorKeys.ModelOptions, { test: 'hello' }, Dummy);
     assignMetadata(DecoratorKeys.ModelOptions, undefined, Dummy);
     expect(Reflect.getMetadata(DecoratorKeys.ModelOptions, Dummy)).to.deep.equal({ test: 'hello' });
+  });
+
+  it('should just run with an non existing value in "mergeMetadata"', () => {
+    class Dummy { }
+    assignMetadata(DecoratorKeys.ModelOptions, { schemaOptions: { _id: false } }, Dummy);
+    expect(mergeMetadata(DecoratorKeys.ModelOptions, undefined, Dummy))
+      .to.deep.equal({ schemaOptions: { _id: false } });
+  });
+
+  it('should just run with an non existing value in "mergeSchemaOptions"', () => {
+    class Dummy { }
+    assignMetadata(DecoratorKeys.ModelOptions, { schemaOptions: { _id: false } }, Dummy);
+    expect(mergeSchemaOptions(undefined, Dummy)).to.deep.equal({ _id: false });
   });
 
   it('merge options with assignMetadata', () => {

--- a/test/tests/shouldRun.test.ts
+++ b/test/tests/shouldRun.test.ts
@@ -172,4 +172,22 @@ export function suite() {
     expect(reflected.schemaOptions).to.have.property('timestamps', true);
     expect(reflected.schemaOptions).to.have.property('_id', true);
   });
+
+  it('TEST', async () => {
+    class Nested {
+      @prop()
+      public hi: number;
+    }
+    class TestClass {
+      @prop({ _id: false })
+      public someprop: Nested;
+    }
+
+    const model = getModelForClass(TestClass);
+    const doc = await model.create({ someprop: { hi: 10 } } as TestClass);
+
+    expect(doc).to.not.be.an('undefined');
+    expect(doc.someprop).to.have.property('hi', 10);
+    expect(doc.someprop).to.not.have.property('_id');
+  });
 }


### PR DESCRIPTION
Tried to fix the Decorator Execution Order problem (#23) 

- cache @prop (@arrayProp @mapProp) to be executed when _buildSchema is called
- disable _id test in biguser
- fix tests for some thing
- outsource uniqueID creation to "utils.createUniqueID"
- add doc note to use the right execution order for something like hooks

Known Issues:
- none known issues anymore, verification needed

This PR might be breaking something (but shouldnt be too much and work like v5)

PS: 
- related mongoose issue https://github.com/Automattic/mongoose/issues/8137
- before this pr, subdocuments wouldn't build parent's properties into its own, because of the call directly to `_buildSchema` but changing it back, dosnt work for _id too

fixes #23 