### PR TITLE
Add back options parameter to getModelForClass

### DIFF
--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -74,10 +74,12 @@ export abstract class Typegoose {
  * const NameModel = getModelForClass(Name);
  * ```
  */
-export function getModelForClass<T, U extends AnyParamConstructor<T>>(cl: U) {
+export function getModelForClass<T, U extends AnyParamConstructor<T>>(cl: U, settings?: IModelOptions) {
   if (typeof cl !== 'function') {
     throw new NoValidClass(cl);
   }
+
+  assignMetadata(DecoratorKeys.ModelOptions, settings, cl);
 
   const options: IModelOptions = Reflect.getMetadata(DecoratorKeys.ModelOptions, cl) || {};
   const name = getName(cl);

--- a/test/tests/shouldRun.test.ts
+++ b/test/tests/shouldRun.test.ts
@@ -154,4 +154,22 @@ export function suite() {
     assignMetadata(DecoratorKeys.ModelOptions, undefined, Dummy);
     expect(Reflect.getMetadata(DecoratorKeys.ModelOptions, Dummy)).to.deep.equal({ test: 'hello' });
   });
+
+  it('merge options with assignMetadata', () => {
+    @modelOptions({ schemaOptions: { timestamps: true, _id: false } })
+    class TestAssignMetadata { }
+
+    getModelForClass(TestAssignMetadata, {
+      // @ts-ignore
+      testOption: 'hello',
+      schemaOptions: { _id: true }
+    });
+
+    const reflected = Reflect.getMetadata(DecoratorKeys.ModelOptions, TestAssignMetadata);
+
+    expect(reflected).to.not.be.an('undefined');
+    expect(reflected).to.have.property('testOption', 'hello');
+    expect(reflected.schemaOptions).to.have.property('timestamps', true);
+    expect(reflected.schemaOptions).to.have.property('_id', true);
+  });
 }


### PR DESCRIPTION
Please consider merging this as being able to override model options (existingMongoose) is very useful in tests.